### PR TITLE
Blackduck: Automated PR: Update cross-spawn/7.0.3 to 7.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
     "@typescript-eslint/parser": "6.18.1",
     "chai": "^4.5.0",
     "concurrently": "^5.3.0",
-    "cross-spawn": "^7.0.3",
+    "cross-spawn": "^7.0.6",
     "cypress": "^13.17.0",
     "eslint": "^8.57.1",
     "eslint-config-standard-with-typescript": "^43.0.1",


### PR DESCRIPTION
## Vulnerabilities associated with cross-spawn/7.0.3
[BDSA-2024-9371](https://openhub.net/vulnerabilities/bdsa/BDSA-2024-9371) *(HIGH)*: node-cross-spawn contains a regular expression catastrophic backtracking issue in its `escapeArgument` function. A remote attacker able to supply specially crafted input to this function could cause a denial-of-service (DoS).

[Click Here To See More Details On Server](https://sca.field-test.blackduck.com/api/projects/8f6724f7-e99c-413c-ba56-94565d3f2ea4/versions/0db9cb8d-b19d-4962-85b7-308ad13ff55f/vulnerability-bom?selectedItem=6d691fe0-5eaf-4535-a776-38efb6c54e8c)